### PR TITLE
Potential fix for code scanning alert no. 54: Code injection

### DIFF
--- a/routes/trackOrder.ts
+++ b/routes/trackOrder.ts
@@ -15,7 +15,7 @@ export function trackOrder () {
     const id = !utils.isChallengeEnabled(challenges.reflectedXssChallenge) ? String(req.params.id).replace(/[^\w-]+/g, '') : utils.trunc(req.params.id, 60)
 
     challengeUtils.solveIf(challenges.reflectedXssChallenge, () => { return utils.contains(id, '<iframe src="javascript:alert(`xss`)">') })
-    db.ordersCollection.find({ $where: `this.orderId === '${id}'` }).then((order: any) => {
+    db.ordersCollection.find({ orderId: id }).then((order: any) => {
       const result = utils.queryResultToJson(order)
       challengeUtils.solveIf(challenges.noSqlOrdersChallenge, () => { return result.data.length > 1 })
       if (result.data[0] === undefined) {


### PR DESCRIPTION
Potential fix for [https://github.com/rcedros/juice-shop-ada-1466/security/code-scanning/54](https://github.com/rcedros/juice-shop-ada-1466/security/code-scanning/54)

To fix this code injection vulnerability, avoid including any user-provided input in strings directly evaluated as code (such as MongoDB `$where` or JavaScript expressions). Instead, use standard query operators whenever possible. In this code, rather than searching with a `$where` clause, the query should use a simple filter: `{ orderId: id }`. 

- Replace the `$where` usage with a direct query object: `.find({ orderId: id })`.
- No changes to input sanitization are required for this fix, as the query will only ever match an exact value.
- This change should be made **only on line 18**, within the `trackOrder` handler in `routes/trackOrder.ts`.
- No new imports or definitions are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
